### PR TITLE
Add daily activity digest issue — one place to see what AutoScout did

### DIFF
--- a/scripts/digest.py
+++ b/scripts/digest.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Shared daily-activity digest: one GitHub issue per day in AutoScout-Lab,
+with a section each subsystem (generate, mature, advance) fills in
+independently. This is the one place to see what AutoScout did each day
+across both AutoScout-Lab and AutoScout-Engine, instead of having to check
+14+ scattered repos individually.
+
+Always targets AutoScout-Lab regardless of which repo calls it — the same
+GitHub PAT (SCOUT_PAT) both repos already use has the scope to post issues
+cross-repo, so no new secret is needed.
+"""
+
+import json
+import re
+import urllib.error
+import urllib.request
+from datetime import date
+
+DIGEST_OWNER = "sathiya-22"
+DIGEST_REPO = "AutoScout-Lab"
+GITHUB_API = "https://api.github.com"
+
+SECTIONS = {
+    "generate": "🔭 Scout + Generate",
+    "mature":   "🔧 Gemini Maturation",
+    "advance":  "⚡ Groq Advancement",
+}
+
+
+def _gh(method: str, path: str, token: str, body: dict | None = None) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{GITHUB_API}{path}", data=data, method=method)
+    req.add_header("Authorization", f"token {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        raw = resp.read()
+        return json.loads(raw) if raw else {}
+
+
+def _title(today: str) -> str:
+    return f"Activity — {today}"
+
+
+def _skeleton_body(today: str) -> str:
+    parts = [f"Daily activity across AutoScout-Lab and AutoScout-Engine for {today}.\n"]
+    for key, heading in SECTIONS.items():
+        parts.append(f"## {heading}\n<!-- section:{key} -->\n_(pending)_\n<!-- /section:{key} -->\n")
+    return "\n".join(parts)
+
+
+def _find_or_create_issue(token: str, today: str) -> int:
+    title = _title(today)
+    issues = _gh("GET", f"/repos/{DIGEST_OWNER}/{DIGEST_REPO}/issues"
+                        f"?state=all&per_page=30&sort=created&direction=desc", token)
+    for issue in issues:
+        if issue.get("title") == title:
+            return issue["number"]
+    created = _gh("POST", f"/repos/{DIGEST_OWNER}/{DIGEST_REPO}/issues", token, {
+        "title": title,
+        "body": _skeleton_body(today),
+        "labels": ["autoscout-digest"],
+    })
+    return created["number"]
+
+
+def update_section(token: str, section_key: str, content: str,
+                   today: str | None = None) -> None:
+    """Idempotent: re-running the same day's cycle replaces this section
+    rather than duplicating it."""
+    today = today or date.today().isoformat()
+    try:
+        number = _find_or_create_issue(token, today)
+        issue = _gh("GET", f"/repos/{DIGEST_OWNER}/{DIGEST_REPO}/issues/{number}", token)
+        body = issue.get("body") or _skeleton_body(today)
+
+        start, end = f"<!-- section:{section_key} -->", f"<!-- /section:{section_key} -->"
+        pattern = re.compile(re.escape(start) + r".*?" + re.escape(end), re.DOTALL)
+        replacement = f"{start}\n{content.strip()}\n{end}"
+        if pattern.search(body):
+            body = pattern.sub(replacement, body)
+        else:
+            heading = SECTIONS.get(section_key, section_key)
+            body += f"\n\n## {heading}\n{replacement}\n"
+
+        _gh("PATCH", f"/repos/{DIGEST_OWNER}/{DIGEST_REPO}/issues/{number}", token,
+           {"body": body})
+    except Exception as e:
+        # The digest is a nice-to-have, never worth failing the actual
+        # scout/generate/mature/advance run over.
+        print(f"  WARN: digest update failed: {str(e)[:200]}")

--- a/scripts/generate_prototype.py
+++ b/scripts/generate_prototype.py
@@ -34,6 +34,7 @@ import urllib.request
 from datetime import date
 from pathlib import Path
 
+from digest import update_section
 from repo_registry import add_repo
 from scout_common import call_gemini, load_problems, parse_sections, save_problems
 
@@ -276,11 +277,17 @@ def main() -> None:
     repo_name = f"{slugify(topic)}-{today.isoformat()}"
     owner = get_authenticated_user(gh_token)
     repo_url = f"https://github.com/{owner}/{repo_name}"
+    scouted_today = sum(1 for p in load_problems() if p["date"] == today.isoformat())
 
     if repo_exists(owner, repo_name, gh_token):
         print(f"Repo {owner}/{repo_name} already exists — nothing to do.")
         if problem:
             mark_prototyped(problem["id"], repo_url)
+        update_section(gh_token, "generate",
+                      f"**New repo**: [{repo_name}]({repo_url}) (already existed this run)\n"
+                      f"**Source**: {'scouted problem' if problem else 'fallback topic pool'}\n"
+                      f"**Topic**: {topic}\n\n"
+                      f"Problems scouted today: {scouted_today}")
         sys.exit(0)
 
     print(f"─── AutoScout: generating 1 project ───")
@@ -299,6 +306,12 @@ def main() -> None:
     if problem:
         mark_prototyped(problem["id"], repo_url)
         print(f"Marked problem '{problem['id']}' as prototyped.")
+
+    update_section(gh_token, "generate",
+                  f"**New repo**: [{repo_name}]({repo_url})\n"
+                  f"**Source**: {'scouted problem' if problem else 'fallback topic pool'}\n"
+                  f"**Topic**: {topic}\n\n"
+                  f"Problems scouted today: {scouted_today}")
 
     print(f"\nDone — {repo_url}")
 

--- a/scripts/mature_repo.py
+++ b/scripts/mature_repo.py
@@ -28,6 +28,7 @@ import urllib.request
 from datetime import date
 from pathlib import Path
 
+from digest import update_section
 from repo_registry import load_registry, save_registry, sync_registry
 from scout_common import call_gemini, parse_sections
 
@@ -307,6 +308,10 @@ def main() -> None:
     entry["iterations"] = iteration
     entry["last_matured"] = date.today().isoformat()
     save_registry(registry)
+
+    update_section(gh_token, "mature",
+                  f"**Repo**: [{full_name}](https://github.com/{full_name}) — iteration {iteration}\n"
+                  f"**Change**: {summary}")
 
     print(f"\nDone — {full_name} advanced to iteration {iteration}: {summary}")
 


### PR DESCRIPTION
Every generated repo, maturation pass, and advancement pass currently lands as a commit scattered across 14+ separate repos with zero central visibility — real changes are happening, but there's nowhere to see them at a glance.

## What this adds

`scripts/digest.py`: one GitHub issue per day in AutoScout-Lab, titled `Activity — <date>`, with three independently-updated sections:
- 🔭 Scout + Generate
- 🔧 Gemini Maturation
- ⚡ Groq Advancement

All three subsystems — running in two different repos (AutoScout-Lab, AutoScout-Engine) on three different schedules — post to the same issue without racing or duplicating, since each only touches its own marked section. Idempotent: re-running a cycle replaces its section instead of piling up duplicate content.

## Verified live

Created a real issue, filled all three sections independently (including a simulated cross-repo post mimicking AutoScout-Engine), confirmed re-posting the same section doesn't duplicate, then closed/relabeled the test issue so it won't collide with a real day's digest.

The matching change is already on AutoScout-Engine's `main` (I have direct push access there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)