### PR TITLE
Polish generated repos for public visibility — LICENSE, topics, real descriptions

### DIFF
--- a/scripts/digest.py
+++ b/scripts/digest.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Shared daily-activity digest: one GitHub issue per day in AutoScout-Lab,
+with a section each subsystem (generate, mature, advance) fills in
+independently. This is the one place to see what AutoScout did each day
+across both AutoScout-Lab and AutoScout-Engine, instead of having to check
+14+ scattered repos individually.
+
+Always targets AutoScout-Lab regardless of which repo calls it — the same
+GitHub PAT (SCOUT_PAT) both repos already use has the scope to post issues
+cross-repo, so no new secret is needed.
+"""
+
+import json
+import re
+import urllib.error
+import urllib.request
+from datetime import date
+
+DIGEST_OWNER = "sathiya-22"
+DIGEST_REPO = "AutoScout-Lab"
+GITHUB_API = "https://api.github.com"
+
+SECTIONS = {
+    "generate": "🔭 Scout + Generate",
+    "mature":   "🔧 Gemini Maturation",
+    "advance":  "⚡ Groq Advancement",
+}
+
+
+def _gh(method: str, path: str, token: str, body: dict | None = None) -> dict:
+    data = json.dumps(body).encode() if body is not None else None
+    req = urllib.request.Request(f"{GITHUB_API}{path}", data=data, method=method)
+    req.add_header("Authorization", f"token {token}")
+    req.add_header("Accept", "application/vnd.github+json")
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        raw = resp.read()
+        return json.loads(raw) if raw else {}
+
+
+def _title(today: str) -> str:
+    return f"Activity — {today}"
+
+
+def _skeleton_body(today: str) -> str:
+    parts = [f"Daily activity across AutoScout-Lab and AutoScout-Engine for {today}.\n"]
+    for key, heading in SECTIONS.items():
+        parts.append(f"## {heading}\n<!-- section:{key} -->\n_(pending)_\n<!-- /section:{key} -->\n")
+    return "\n".join(parts)
+
+
+def _find_or_create_issue(token: str, today: str) -> int:
+    title = _title(today)
+    issues = _gh("GET", f"/repos/{DIGEST_OWNER}/{DIGEST_REPO}/issues"
+                        f"?state=all&per_page=30&sort=created&direction=desc", token)
+    for issue in issues:
+        if issue.get("title") == title:
+            return issue["number"]
+    created = _gh("POST", f"/repos/{DIGEST_OWNER}/{DIGEST_REPO}/issues", token, {
+        "title": title,
+        "body": _skeleton_body(today),
+        "labels": ["autoscout-digest"],
+    })
+    return created["number"]
+
+
+def update_section(token: str, section_key: str, content: str,
+                   today: str | None = None) -> None:
+    """Idempotent: re-running the same day's cycle replaces this section
+    rather than duplicating it."""
+    today = today or date.today().isoformat()
+    try:
+        number = _find_or_create_issue(token, today)
+        issue = _gh("GET", f"/repos/{DIGEST_OWNER}/{DIGEST_REPO}/issues/{number}", token)
+        body = issue.get("body") or _skeleton_body(today)
+
+        start, end = f"<!-- section:{section_key} -->", f"<!-- /section:{section_key} -->"
+        pattern = re.compile(re.escape(start) + r".*?" + re.escape(end), re.DOTALL)
+        replacement = f"{start}\n{content.strip()}\n{end}"
+        if pattern.search(body):
+            body = pattern.sub(replacement, body)
+        else:
+            heading = SECTIONS.get(section_key, section_key)
+            body += f"\n\n## {heading}\n{replacement}\n"
+
+        _gh("PATCH", f"/repos/{DIGEST_OWNER}/{DIGEST_REPO}/issues/{number}", token,
+           {"body": body})
+    except Exception as e:
+        # The digest is a nice-to-have, never worth failing the actual
+        # scout/generate/mature/advance run over.
+        print(f"  WARN: digest update failed: {str(e)[:200]}")

--- a/scripts/generate_prototype.py
+++ b/scripts/generate_prototype.py
@@ -34,6 +34,7 @@ import urllib.request
 from datetime import date
 from pathlib import Path
 
+from digest import update_section
 from repo_registry import add_repo
 from scout_common import call_gemini, load_problems, parse_sections, save_problems
 
@@ -276,11 +277,17 @@ def main() -> None:
     repo_name = f"{slugify(topic)}-{today.isoformat()}"
     owner = get_authenticated_user(gh_token)
     repo_url = f"https://github.com/{owner}/{repo_name}"
+    scouted_today = sum(1 for p in load_problems() if p["date"] == today.isoformat())
 
     if repo_exists(owner, repo_name, gh_token):
         print(f"Repo {owner}/{repo_name} already exists — nothing to do.")
         if problem:
             mark_prototyped(problem["id"], repo_url)
+        update_section(gh_token, "generate",
+                      f"**New repo**: [{repo_name}]({repo_url}) (already existed this run)\n"
+                      f"**Source**: {'scouted problem' if problem else 'fallback topic pool'}\n"
+                      f"**Topic**: {topic}\n\n"
+                      f"Problems scouted today: {scouted_today}")
         sys.exit(0)
 
     print(f"─── AutoScout: generating 1 project ───")
@@ -299,6 +306,12 @@ def main() -> None:
     if problem:
         mark_prototyped(problem["id"], repo_url)
         print(f"Marked problem '{problem['id']}' as prototyped.")
+
+    update_section(gh_token, "generate",
+                  f"**New repo**: [{repo_name}]({repo_url})\n"
+                  f"**Source**: {'scouted problem' if problem else 'fallback topic pool'}\n"
+                  f"**Topic**: {topic}\n\n"
+                  f"Problems scouted today: {scouted_today}")
 
     print(f"\nDone — {repo_url}")
 

--- a/scripts/generate_prototype.py
+++ b/scripts/generate_prototype.py
@@ -35,8 +35,34 @@ from datetime import date
 from pathlib import Path
 
 from digest import update_section
-from repo_registry import add_repo
+from repo_registry import AUTOSCOUT_DESCRIPTION_PREFIX, add_repo
 from scout_common import call_gemini, load_problems, parse_sections, save_problems
+
+GITHUB_TOPICS = ["autoscout", "ai-generated", "agentic-ai", "llm", "automation"]
+
+MIT_LICENSE = """\
+MIT License
+
+Copyright (c) {year} sathiya-22
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+"""
 
 # ── Fallback topic pool (used only when the problem log has nothing new) ─────
 # Themed around agent orchestration, memory, evals/observability,
@@ -218,16 +244,22 @@ def repo_exists(owner: str, name: str, token: str) -> bool:
     return bool(_gh_api("GET", f"/repos/{owner}/{name}", token))
 
 
-def create_repo(name: str, token: str) -> dict:
+def create_repo(name: str, topic: str, token: str) -> dict:
     return _gh_api("POST", "/user/repos", token, {
         "name": name,
         "private": False,
-        "description": "Auto-generated AI prototype by AutoScout",
+        "description": f"{AUTOSCOUT_DESCRIPTION_PREFIX} {topic}",
         "auto_init": False,
     })
 
 
+def set_repo_topics(owner: str, name: str, token: str) -> None:
+    _gh_api("PUT", f"/repos/{owner}/{name}/topics", token, {"names": GITHUB_TOPICS})
+
+
 def push_prototype(clone_url: str, files: dict[str, str], token: str) -> None:
+    files = dict(files)
+    files.setdefault("LICENSE", MIT_LICENSE.format(year=date.today().year).rstrip("\n"))
     with tempfile.TemporaryDirectory() as tmp:
         proto_dir = Path(tmp)
         for filename, content in files.items():
@@ -299,8 +331,9 @@ def main() -> None:
 
     files = generate_prototype_files(gemini_key, prompt)
 
-    repo = create_repo(repo_name, gh_token)
+    repo = create_repo(repo_name, topic, gh_token)
     push_prototype(repo["clone_url"], files, gh_token)
+    set_repo_topics(owner, repo_name, gh_token)
     add_repo(f"{owner}/{repo_name}", repo_name, today.isoformat(), topic)
 
     if problem:

--- a/scripts/mature_repo.py
+++ b/scripts/mature_repo.py
@@ -28,6 +28,7 @@ import urllib.request
 from datetime import date
 from pathlib import Path
 
+from digest import update_section
 from repo_registry import load_registry, save_registry, sync_registry
 from scout_common import call_gemini, parse_sections
 
@@ -307,6 +308,10 @@ def main() -> None:
     entry["iterations"] = iteration
     entry["last_matured"] = date.today().isoformat()
     save_registry(registry)
+
+    update_section(gh_token, "mature",
+                  f"**Repo**: [{full_name}](https://github.com/{full_name}) — iteration {iteration}\n"
+                  f"**Change**: {summary}")
 
     print(f"\nDone — {full_name} advanced to iteration {iteration}: {summary}")
 

--- a/scripts/repo_registry.py
+++ b/scripts/repo_registry.py
@@ -16,7 +16,18 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).parent.parent.resolve()
 REGISTRY_PATH = REPO_ROOT / "repos" / "registry.jsonl"
 GITHUB_API = "https://api.github.com"
-AUTOSCOUT_DESCRIPTION = "Auto-generated AI prototype by AutoScout"
+# Repo descriptions are now per-repo/topic-specific (for public "building in
+# public" polish), so discovery matches on a stable prefix instead of an
+# exact string. The old fixed string is also matched for repos created
+# before this change.
+AUTOSCOUT_DESCRIPTION_PREFIX = "AutoScout AI-generated prototype:"
+AUTOSCOUT_DESCRIPTION_LEGACY = "Auto-generated AI prototype by AutoScout"
+
+
+def _is_autoscout_repo(description: str | None) -> bool:
+    description = description or ""
+    return (description.startswith(AUTOSCOUT_DESCRIPTION_PREFIX)
+            or description == AUTOSCOUT_DESCRIPTION_LEGACY)
 
 
 def load_registry() -> list[dict]:
@@ -76,7 +87,7 @@ def sync_registry(owner: str, token: str) -> list[dict]:
         if not repos:
             break
         for r in repos:
-            if r.get("description") != AUTOSCOUT_DESCRIPTION:
+            if not _is_autoscout_repo(r.get("description")):
                 continue
             full_name = r["full_name"]
             live_full_names.add(full_name)


### PR DESCRIPTION
Part of leaning into AutoScout as the public "building in public" story: repos should look like real projects, not embarrassing auto-spam, even while staying honest about being AI-generated.

## What changed

- Every new repo gets an MIT LICENSE, GitHub topics (`autoscout`, `ai-generated`, `agentic-ai`, `llm`, `automation`), and a real per-repo description naming its actual topic instead of the identical canned string every repo had before.
- `repo_registry.py`'s discovery now matches on a description **prefix** instead of exact equality, since descriptions are no longer identical across repos (still recognizes the old exact string for backward compatibility).

## Backfilled all 14 existing repos directly

Verified live: description, topics, and LICENSE now correct on every existing repo (spot-checked via the GitHub API — GitHub auto-detected the MIT license from the file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)