### PR TITLE
Fix unparseable manifest files breaking GitHub's Dependabot dependency-graph job

### DIFF
--- a/ai_scout_batch_2026_03_31/quantizeflow/pyproject.toml
+++ b/ai_scout_batch_2026_03_31/quantizeflow/pyproject.toml
@@ -1,4 +1,3 @@
-```toml
 [build-system]
 requires = ["setuptools>=61.0", "wheel", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
@@ -53,7 +52,7 @@ dependencies = [
 Homepage = "https://github.com/quantizeflow/quantizeflow" # Placeholder
 Repository = "https://github.com/quantizeflow/quantizeflow"
 Documentation = "https://quantizeflow.readthedocs.io" # Placeholder
-Bug Tracker = "https://github.com/quantizeflow/quantizeflow/issues"
+"Bug Tracker" = "https://github.com/quantizeflow/quantizeflow/issues"
 
 [project.optional-dependencies]
 dev = [
@@ -117,4 +116,3 @@ addopts = "--cov=quantizeflow --cov-report=term-missing -ra"
 testpaths = "tests"
 python_files = "test_*.py"
 xfail_strict = true
-```

--- a/ai_scout_batch_2026_04_01/hybrid-rag-prototype/pyproject.toml
+++ b/ai_scout_batch_2026_04_01/hybrid-rag-prototype/pyproject.toml
@@ -1,4 +1,3 @@
-```toml
 [project]
 name = "hybrid-rag-system"
 version = "0.1.0"
@@ -110,4 +109,3 @@ known-first-party = ["src"] # Helps ruff's isort organize imports correctly
 pythonpath = ["src"] # Add 'src' to the Python path for tests
 addopts = "--import-mode=importlib --cov=src --cov-report=term-missing" # Test coverage with missing lines
 testpaths = "tests" # Specify the directory for tests
-```

--- a/ai_scout_batch_2026_05_05/active-graph-rag-prototype/pyproject.toml
+++ b/ai_scout_batch_2026_05_05/active-graph-rag-prototype/pyproject.toml
@@ -1,4 +1,3 @@
-```toml
 [project]
 name = "graph-rag-scaling-prototype"
 version = "0.1.0"
@@ -137,4 +136,3 @@ src = ["src", "config"] # Apply Ruff to these directories
 
 [tool.ruff.per-file-ignores]
 "tests/*" = ["D"] # Do not enforce docstrings in test files
-```

--- a/ai_scout_batch_2026_06_14/contrastive-retrieval-reranker-prototype/requirements.txt
+++ b/ai_scout_batch_2026_06_14/contrastive-retrieval-reranker-prototype/requirements.txt
@@ -1,4 +1,3 @@
 google-generativeai
 pydantic
 pydantic-settings
-```

--- a/ai_scout_batch_2026_06_17/multi-hop-question-answering-agent-prototype/requirements.txt
+++ b/ai_scout_batch_2026_06_17/multi-hop-question-answering-agent-prototype/requirements.txt
@@ -1,4 +1,3 @@
 google-generative-ai
 pydantic
 pydantic-settings
-```

--- a/ai_scout_batch_2026_06_21/task-decomposition-and-planning-agent-prototype/requirements.txt
+++ b/ai_scout_batch_2026_06_21/task-decomposition-and-planning-agent-prototype/requirements.txt
@@ -1,4 +1,3 @@
 google-generative-ai
 pydantic
 pydantic-settings
-```

--- a/ai_scout_batch_2026_06_22/llm-powered-data-cleaning-pipeline-prototype/requirements.txt
+++ b/ai_scout_batch_2026_06_22/llm-powered-data-cleaning-pipeline-prototype/requirements.txt
@@ -1,4 +1,3 @@
 google-generative-ai
 pydantic
 pydantic-settings
-```

--- a/ai_scout_batch_2026_06_27/constitutional-ai-filter-pipeline-prototype/requirements.txt
+++ b/ai_scout_batch_2026_06_27/constitutional-ai-filter-pipeline-prototype/requirements.txt
@@ -1,4 +1,3 @@
 google-generativeai
 pydantic
 pydantic-settings
-```


### PR DESCRIPTION
Found while doing a health sweep: GitHub's native dependency-graph job (not one of our own workflows) has been silently failing on every run since 2026-07-20 — `/ai_scout_batch_2026_03_31/quantizeflow/pyproject.toml not parseable`.

## Root cause

A systemic bug from before the fence-stripping prompt instruction existed: the historical `ai_scout_batch_*` content (pre one-repo-per-day pipeline) has stray literal markdown code-fence markers (```toml / ```) baked into ~100+ files across the legacy tree. Most are cosmetic — `.py`/`.md` files still work fine — but **3 `pyproject.toml` files and 5 `requirements.txt` files** had them too, which genuinely breaks Dependabot's static parser and aborts the graph update for the **entire repo** on just one bad file.

## Fixed

- All 8 broken manifests (fence markers stripped)
- One additional real bug found in the same pass: `quantizeflow/pyproject.toml` had `Bug Tracker = "..."` as a bare TOML key — invalid, since keys with spaces must be quoted. Fixed to `"Bug Tracker" = "..."`.

## Verified

- Every `pyproject.toml` in the tree now parses cleanly with `tomllib`
- No `requirements.txt` or `pyproject.toml` anywhere still contains a stray fence marker
- Confirmed the current pipeline (`generate_prototype.py`, `mature_repo.py`) already guards against this via its "no markdown fences" prompt instruction — this was legacy-only, not a live regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)