### PR TITLE
feat: real research stage — measured benchmarks instead of narrated p…

### DIFF
--- a/scripts/fleet_report.py
+++ b/scripts/fleet_report.py
@@ -56,7 +56,7 @@ def render(lab: list[dict], engine: dict[str, dict]) -> str:
         f"{total_gemini} Gemini maturation passes, "
         f"{total_groq} Groq advancement passes. "
         f"Last updated {today.isoformat()}.\n\n"
-        f"🟢 active = starred or <14 days old, rotates freely · "
+        f"🟢 active = starred or <30 days old, rotates freely · "
         f"💤 dormant = revisited monthly\n\n"
         f"| Repo | Created | ⭐ | Gemini | Groq | Last touched | Tier |\n"
         f"|---|---|---|---|---|---|---|\n"

--- a/scripts/mature_repo.py
+++ b/scripts/mature_repo.py
@@ -36,6 +36,7 @@ from pathlib import Path
 
 from digest import update_section
 from repo_registry import load_registry, save_registry, sync_registry
+from research import RESEARCH_LOG, run_research_stage
 from scout_common import broken_python_files, call_gemini, parse_sections
 from verify import verify_python_repo
 
@@ -126,8 +127,10 @@ def fetch_repo_context(full_name: str, token: str) -> dict[str, str] | None:
 
 # ── Rotation ─────────────────────────────────────────────────────────────────
 
-ACTIVE_AGE_DAYS = 14    # new repos stay in the active tier this long
-DORMANT_REVISIT_DAYS = 30  # untouched dormant repos become due after this
+ACTIVE_AGE_DAYS = 30    # new repos stay in the active tier this long — raised
+                        # from 14 so each repo gets more real-research passes
+                        # before demotion, without slowing daily new-repo creation
+DORMANT_REVISIT_DAYS = 45  # untouched dormant repos become due after this
 
 
 def is_active(entry: dict, today: date | None = None) -> bool:
@@ -400,6 +403,17 @@ def main() -> None:
     edited[GROWTH_LOG] = new_growth_log
 
     summary = commit_summary(old_growth_log, new_growth_log)
+
+    old_research_log = files.get(RESEARCH_LOG, "")
+    research_files, research_entry = run_research_stage(
+        call_gemini, gemini_key, entry, {**files, **edited}, old_research_log,
+        today, iteration)
+    if research_entry:
+        edited[RESEARCH_LOG] = (old_research_log.rstrip("\n") + "\n\n" if old_research_log.strip()
+                                else "") + research_entry
+        edited.update(research_files)
+        summary += " + research"
+        print(f"  research  : {research_entry.splitlines()[1]}")
 
     try:
         push_maturation(full_name, edited, gh_token, iteration, summary)

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -1,0 +1,224 @@
+#!/usr/bin/env python3
+"""AutoScout's real-research stage.
+
+The maturation loop used to let the model *narrate* progress ("we tried X,
+found Y") with nothing behind the claim — indistinguishable from fabrication.
+This stage instead makes the model propose ONE concrete, narrow question
+answerable by code, actually RUNS that code in the same sandbox verify.py
+uses, and treats only what the script's stdout contains as ground truth.
+
+The model gets exactly one way to report a result: print a line starting
+with RESULT_MARKER followed by a single-line JSON object. Anything else it
+claims is not trusted. A second, separate call may add prose interpretation,
+but sanitize_interpretation() strips any number that doesn't actually appear
+in the measured result — the same "don't trust the model to reproduce facts,
+verify deterministically" pattern as mature_repo.py's sanitize_log().
+
+If the model can't propose something runnable, a qualitative question is
+allowed (per project scope) but is always logged as explicitly unverified —
+never presented with the same confidence as a measured result.
+
+The benchmark script itself is committed alongside the log entry, so a
+reader can rerun it and check the claim rather than take it on faith.
+"""
+
+import json
+import re
+
+from verify import run_script_in_sandbox
+
+RESEARCH_LOG = "RESEARCH.md"
+RESULT_MARKER = "AUTOSCOUT_RESEARCH_RESULT:"
+RESEARCH_MAX_TOKENS = 2500
+INTERPRET_MAX_TOKENS = 400
+
+SYSTEM_RESEARCH_PROMPT = (
+    "You are AutoScout's research stage. Propose ONE concrete, narrow "
+    "question about this repo's specific problem space that can be answered "
+    "by writing and running a small, self-contained Python script using only "
+    "this repo's existing dependencies or the standard library — e.g. "
+    "comparing two algorithms/approaches on speed, memory, correctness, or "
+    "output quality using synthetic or fixture data. No real API keys, no "
+    "network calls, no GPU. Prefer a measurable benchmark; only fall back to "
+    "a qualitative investigation (reasoning about two approaches without "
+    "running code) if a benchmark genuinely isn't possible here, and say so.\n\n"
+    f"Your script MUST print exactly one line starting with '{RESULT_MARKER} ' "
+    "followed by a single-line JSON object of your measured metrics (e.g. "
+    '{"approach_a_ms": 12.4, "approach_b_ms": 31.0}). This is the ONLY way '
+    "your results are trusted — anything you claim outside this JSON line is "
+    "ignored, so do not skip it.\n\n"
+    "Output in EXACTLY this form:\n"
+    "QUESTION: <one sentence>\n"
+    "TYPE: benchmark|qualitative\n"
+    "=== research/<descriptive-name>.py ===\n"
+    "<script content — required only if TYPE is benchmark>\n"
+    "NOTES: <required only if TYPE is qualitative — your reasoning, clearly "
+    "unverified, not measured>"
+)
+
+PROPOSE_TEMPLATE = """\
+Repo: {full_name}
+Problem: {topic}
+Iteration: {iteration}
+
+Prior research log (complete history, verbatim):
+{research_log}
+
+Current files:
+{file_dump}
+
+Propose the next research question per your instructions.
+"""
+
+INTERPRET_TEMPLATE = """\
+Research question: {question}
+
+You proposed and ran a benchmark script; here is the ACTUAL measured result \
+— this is ground truth, do not restate different numbers or invent \
+additional metrics beyond what's here:
+{result_json}
+
+Write a short (2-4 sentence) interpretation: what this measurement means for \
+this project, and a concrete recommendation (adopt an approach, keep things \
+as they are, or investigate further). Reference ONLY the numbers given \
+above — no other numeric claim.
+"""
+
+
+def build_propose_prompt(entry: dict, files: dict[str, str], research_log: str) -> str:
+    dump = "\n\n".join(f"----- FILE: {path} -----\n{content}"
+                       for path, content in files.items())
+    return PROPOSE_TEMPLATE.format(
+        full_name=entry["full_name"],
+        topic=entry.get("topic", entry["name"]),
+        iteration=entry.get("iterations", 0) + 1,
+        research_log=research_log or "(none yet — this is the first research pass.)",
+        file_dump=dump,
+    )
+
+
+def parse_research_proposal(raw: str) -> dict | None:
+    q_match = re.search(r"QUESTION:\s*(.+)", raw)
+    t_match = re.search(r"TYPE:\s*(benchmark|qualitative)", raw, re.IGNORECASE)
+    if not q_match or not t_match:
+        return None
+    question = q_match.group(1).strip()
+    kind = t_match.group(1).lower()
+
+    if kind == "qualitative":
+        notes_match = re.search(r"NOTES:\s*(.+)", raw, re.DOTALL)
+        return {"question": question, "type": "qualitative",
+                "notes": notes_match.group(1).strip() if notes_match else ""}
+
+    file_match = re.search(r"=== (research/[\w.\-]+\.py) ===\n(.*?)(?=\Z)", raw, re.DOTALL)
+    if not file_match:
+        return None
+    script_filename = file_match.group(1).strip()
+    if ".." in script_filename.split("/"):
+        return None
+    return {"question": question, "type": "benchmark",
+            "script_filename": script_filename,
+            "script_content": file_match.group(2).strip()}
+
+
+def extract_result(stdout: str) -> dict | None:
+    for line in stdout.splitlines():
+        if line.startswith(RESULT_MARKER):
+            try:
+                return json.loads(line[len(RESULT_MARKER):].strip())
+            except json.JSONDecodeError:
+                return None
+    return None
+
+
+def _numbers_in(text: str) -> set[str]:
+    return set(re.findall(r"\d+\.?\d*", text))
+
+
+def sanitize_interpretation(interpretation: str, result: dict, question: str) -> str:
+    """Only trust prose that doesn't introduce numbers absent from the
+    actual measured result — a model asked to interpret real numbers can
+    still slip in a fabricated one (e.g. a made-up percentage), and a
+    plausible-sounding fabricated number is much harder to catch later than
+    a wrong date was in sanitize_log()."""
+    allowed = _numbers_in(json.dumps(result)) | _numbers_in(question)
+    foreign = _numbers_in(interpretation) - allowed
+    if foreign:
+        return (f"(Model interpretation discarded — it referenced number(s) "
+                f"{sorted(foreign)} not present in the measured data below.)")
+    return interpretation.strip()
+
+
+def compose_research_entry(today: str, iteration: int, question: str, kind: str,
+                           script_filename: str | None, status: str,
+                           result: dict | None, interpretation: str) -> str:
+    lines = [f"### {today} — iteration {iteration} research", f"**Question:** {question}"]
+    if kind == "benchmark":
+        if status == "ok" and result is not None:
+            lines.append(f"**Script:** `{script_filename}` (committed — rerun it yourself to verify)")
+            lines.append(f"**Measured result:** `{json.dumps(result)}`")
+            lines.append(f"**Interpretation:** {interpretation}")
+        else:
+            lines.append(f"**Status:** benchmark attempted but produced no verifiable "
+                         f"result ({status}) — no conclusion drawn.")
+    else:
+        lines.append(f"**Notes (qualitative, unverified — not a measured result):** "
+                     f"{interpretation}")
+    return "\n".join(lines) + "\n"
+
+
+def run_research_stage(call_llm, api_key: str, entry: dict, files: dict[str, str],
+                       research_log: str, today: str, iteration: int) -> tuple[dict, str]:
+    """Returns (extra_files, log_entry_text). Never raises — a failed or
+    unusable proposal just yields ('', {}) so it never blocks the main
+    maturation flow."""
+    try:
+        raw = call_llm(api_key, build_propose_prompt(entry, files, research_log),
+                       SYSTEM_RESEARCH_PROMPT, max_tokens=RESEARCH_MAX_TOKENS)
+    except RuntimeError as e:
+        print(f"  research stage: proposal call failed: {e}")
+        return {}, ""
+
+    proposal = parse_research_proposal(raw)
+    if not proposal:
+        print("  research stage: no usable proposal in model output")
+        return {}, ""
+
+    if proposal["type"] == "qualitative":
+        entry_text = compose_research_entry(
+            today, iteration, proposal["question"], "qualitative",
+            None, "n/a", None, proposal.get("notes", "").strip() or "(no notes given)")
+        return {}, entry_text
+
+    script_filename = proposal["script_filename"]
+    sandbox_files = {**files, script_filename: proposal["script_content"]}
+    run = run_script_in_sandbox(sandbox_files, script_filename)
+
+    if run["status"] != "ran":
+        print(f"  research stage: benchmark script failed to run ({run['reason']})")
+        entry_text = compose_research_entry(
+            today, iteration, proposal["question"], "benchmark",
+            script_filename, "did not run", None, "")
+        return {}, entry_text
+
+    result = extract_result(run["output"])
+    if result is None:
+        print("  research stage: benchmark ran but printed no result marker")
+        entry_text = compose_research_entry(
+            today, iteration, proposal["question"], "benchmark",
+            script_filename, "no verifiable result", None, "")
+        return {}, entry_text
+
+    try:
+        raw_interp = call_llm(
+            api_key,
+            INTERPRET_TEMPLATE.format(question=proposal["question"], result_json=json.dumps(result)),
+            SYSTEM_RESEARCH_PROMPT, max_tokens=INTERPRET_MAX_TOKENS)
+        interpretation = sanitize_interpretation(raw_interp, result, proposal["question"])
+    except RuntimeError:
+        interpretation = "(interpretation call failed — see measured result above.)"
+
+    entry_text = compose_research_entry(
+        today, iteration, proposal["question"], "benchmark",
+        script_filename, "ok", result, interpretation)
+    return {script_filename: proposal["script_content"]}, entry_text

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -113,3 +113,57 @@ def verify_python_repo(files: dict[str, str]) -> dict:
             return {"ok": True, "reason": "clean exit"}
         ok, reason = _classify_failure(result.stderr)
         return {"ok": ok, "reason": reason}
+
+
+def run_script_in_sandbox(files: dict[str, str], script_filename: str,
+                          timeout: int = RUN_TIMEOUT_SEC) -> dict:
+    """Runs `script_filename` (already present in `files`) inside the same
+    isolated sandbox as verify_python_repo, and returns its captured stdout.
+
+    Used by the research stage to get a REAL, ground-truth measurement
+    instead of trusting whatever numbers the model claims — the model
+    proposes the benchmark, but only what this function actually observes
+    the script print is ever treated as fact. Never receives real secrets
+    (env built from scratch, same as verify_python_repo)."""
+    if script_filename not in files:
+        return {"status": "error", "output": "", "reason": "script file missing from file set"}
+
+    with tempfile.TemporaryDirectory() as tmp:
+        repo_dir = Path(tmp) / "repo"
+        repo_dir.mkdir()
+        for filename, content in files.items():
+            target = repo_dir / filename
+            target.parent.mkdir(parents=True, exist_ok=True)
+            target.write_text(content + "\n", encoding="utf-8")
+
+        venv_dir = Path(tmp) / "venv"
+        try:
+            venv.create(venv_dir, with_pip=True)
+        except Exception as e:
+            return {"status": "error", "output": "", "reason": f"venv creation failed (infra): {e}"}
+
+        py, pip = venv_dir / "bin" / "python", venv_dir / "bin" / "pip"
+        req_file = repo_dir / REQUIREMENTS
+        if req_file.exists():
+            try:
+                subprocess.run(
+                    [str(pip), "install", "-q", "-r", str(req_file)],
+                    cwd=repo_dir, capture_output=True, text=True,
+                    timeout=INSTALL_TIMEOUT_SEC, env=dict(SANDBOX_ENV),
+                )
+            except subprocess.TimeoutExpired:
+                return {"status": "error", "output": "", "reason": "pip install timed out (infra)"}
+
+        try:
+            result = subprocess.run(
+                [str(py), script_filename],
+                cwd=repo_dir, capture_output=True, text=True,
+                timeout=timeout, stdin=subprocess.DEVNULL, env=dict(SANDBOX_ENV),
+            )
+        except subprocess.TimeoutExpired:
+            return {"status": "error", "output": "", "reason": f"timed out after {timeout}s"}
+
+        if result.returncode != 0:
+            return {"status": "error", "output": result.stdout + result.stderr,
+                    "reason": f"exit code {result.returncode}: {result.stderr[-300:]}"}
+        return {"status": "ran", "output": result.stdout, "reason": "clean exit"}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -17,6 +17,8 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 import mature_repo  # noqa: E402 — imported as a module so call_gemini can be patched
 from generate_prototype import derive_topics  # noqa: E402
 from mature_repo import commit_summary, pick_due_repo, sanitize_log  # noqa: E402
+from research import (extract_result, parse_research_proposal,  # noqa: E402
+                      run_research_stage, sanitize_interpretation)
 from scout_common import (broken_python_files, parse_json_lenient,  # noqa: E402
                           parse_sections, slugify)
 from scout_problems import find_near_duplicate  # noqa: E402
@@ -229,6 +231,99 @@ class TestVerifyWithRetries(unittest.TestCase):
             verified, reason = mature_repo.verify_with_retries("fake-key", base, edited)
         self.assertIsNone(verified)
         self.assertIn("ImportError", reason)
+
+
+class TestResearchProposalParsing(unittest.TestCase):
+    def test_benchmark_proposal_parsed(self):
+        raw = ("QUESTION: is list comprehension faster than a for-loop here?\n"
+              "TYPE: benchmark\n"
+              "=== research/loop_bench.py ===\n"
+              "print('AUTOSCOUT_RESEARCH_RESULT: {\"a\": 1}')\n")
+        parsed = parse_research_proposal(raw)
+        self.assertEqual(parsed["type"], "benchmark")
+        self.assertEqual(parsed["script_filename"], "research/loop_bench.py")
+        self.assertIn("AUTOSCOUT_RESEARCH_RESULT", parsed["script_content"])
+
+    def test_qualitative_proposal_parsed(self):
+        raw = "QUESTION: which library fits better?\nTYPE: qualitative\nNOTES: library X has more features.\n"
+        parsed = parse_research_proposal(raw)
+        self.assertEqual(parsed["type"], "qualitative")
+        self.assertIn("library X", parsed["notes"])
+
+    def test_missing_question_rejected(self):
+        self.assertIsNone(parse_research_proposal("TYPE: benchmark\n"))
+
+    def test_path_traversal_rejected(self):
+        raw = ("QUESTION: q\nTYPE: benchmark\n"
+              "=== research/../../evil.py ===\nprint('hi')\n")
+        self.assertIsNone(parse_research_proposal(raw))
+
+
+class TestExtractResult(unittest.TestCase):
+    def test_extracts_json_after_marker(self):
+        stdout = "some noise\nAUTOSCOUT_RESEARCH_RESULT: {\"ms\": 12.5}\nmore noise\n"
+        self.assertEqual(extract_result(stdout), {"ms": 12.5})
+
+    def test_no_marker_returns_none(self):
+        self.assertIsNone(extract_result("just some output\n"))
+
+    def test_malformed_json_returns_none(self):
+        self.assertIsNone(extract_result("AUTOSCOUT_RESEARCH_RESULT: not json\n"))
+
+
+class TestSanitizeInterpretation(unittest.TestCase):
+    def test_clean_interpretation_kept(self):
+        result = {"a_ms": 12.5, "b_ms": 31.0}
+        text = "Approach A at 12.5ms beats approach B at 31.0ms — adopt A."
+        self.assertEqual(sanitize_interpretation(text, result, "q"), text)
+
+    def test_fabricated_number_discarded(self):
+        result = {"a_ms": 12.5, "b_ms": 31.0}
+        text = "This is a 47% improvement, clearly worth adopting."
+        out = sanitize_interpretation(text, result, "q")
+        self.assertIn("discarded", out)
+
+    def test_number_from_question_allowed(self):
+        result = {"speedup": 2.0}
+        text = "Comparing across 5 runs confirms a speedup of 2.0x."
+        # "5" appears in the question, "2.0" appears in the result — nothing foreign.
+        self.assertEqual(
+            sanitize_interpretation(text, result, "average of 5 runs"), text)
+
+
+class TestRunResearchStage(unittest.TestCase):
+    def test_benchmark_success_produces_entry_and_script_file(self):
+        proposal_raw = ("QUESTION: is A faster than B?\nTYPE: benchmark\n"
+                        "=== research/bench.py ===\n"
+                        "print('AUTOSCOUT_RESEARCH_RESULT: {\"a_ms\": 1.0, \"b_ms\": 2.0}')\n")
+        interp_raw = "A at 1.0ms beats B at 2.0ms — adopt A."
+        calls = iter([proposal_raw, interp_raw])
+        call_llm = unittest.mock.Mock(side_effect=lambda *a, **k: next(calls))
+
+        extra_files, entry_text = run_research_stage(
+            call_llm, "fake-key", {"full_name": "x/y", "name": "y", "topic": "t", "iterations": 0},
+            {"main.py": "print('hi')\n"}, "", "2026-07-27", 1)
+
+        self.assertIn("research/bench.py", extra_files)
+        self.assertIn("Measured result", entry_text)
+        self.assertIn("adopt A", entry_text)
+
+    def test_no_proposal_yields_nothing(self):
+        call_llm = unittest.mock.Mock(return_value="garbage, no fields")
+        extra_files, entry_text = run_research_stage(
+            call_llm, "fake-key", {"full_name": "x/y", "name": "y", "topic": "t", "iterations": 0},
+            {"main.py": "print('hi')\n"}, "", "2026-07-27", 1)
+        self.assertEqual(extra_files, {})
+        self.assertEqual(entry_text, "")
+
+    def test_qualitative_proposal_logged_as_unverified(self):
+        call_llm = unittest.mock.Mock(
+            return_value="QUESTION: which lib?\nTYPE: qualitative\nNOTES: lib X seems richer.\n")
+        extra_files, entry_text = run_research_stage(
+            call_llm, "fake-key", {"full_name": "x/y", "name": "y", "topic": "t", "iterations": 0},
+            {"main.py": "print('hi')\n"}, "", "2026-07-27", 1)
+        self.assertEqual(extra_files, {})
+        self.assertIn("unverified", entry_text)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
…rogress

Maturation passes previously could only narrate progress ("we tried X, found Y") with nothing behind the claim — the same trust gap that already caused fabricated log history once. This adds a research stage that proposes ONE narrow, concrete question, writes a small benchmark script, actually RUNS it in the existing sandbox (verify.py), and treats only a deterministic marker line in stdout as ground truth. A second model call may add prose interpretation, but sanitize_interpretation() strips any number that doesn't appear in the measured result, so a plausible-sounding fabricated number can't slip through unnoticed.

The benchmark script is committed alongside the RESEARCH.md entry so a reader can rerun it and verify the claim rather than take it on faith. When a benchmark genuinely isn't possible, a qualitative question is allowed but always logged as explicitly unverified.

Also raises ACTIVE_AGE_DAYS 14→30 (and DORMANT_REVISIT_DAYS 30→45) so each repo gets more real-research passes before demotion, without slowing daily new-repo creation.