### PR TITLE
Frozen eval harness: score-gated maturation

### DIFF
--- a/scripts/eval_harness.py
+++ b/scripts/eval_harness.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Frozen eval harness: score-gated maturation.
+
+research.py answers one-off questions. This module answers a standing one:
+"did this cycle's change make the repo measurably better or worse?" On a
+repo's first cycle with a research key available, the model proposes a
+FIXED eval/dataset.json + eval/run_eval.py once; every cycle after, both
+files are frozen (see freeze_eval_files()) — the model is never allowed to
+rewrite the yardstick it's being measured against, only the code being
+measured, regardless of what the prompt asks — freeze_eval_files() strips
+any attempted edit to them deterministically, the same "don't trust
+compliance" pattern as sanitize_log() and research.py's marker-only trust.
+
+Every pass runs the same eval before and after its edit. A regression on
+the deterministic score aborts the push exactly like a verify_with_retries
+failure, because a real number going down is not noise. A separate,
+non-gating LLM-judge opinion is also collected and logged for context, but
+never itself grounds for reverting a change — a judge call has run-to-run
+noise a measured score doesn't.
+"""
+
+import json
+import re
+
+from verify import extract_marker_json, run_script_in_sandbox
+
+EVAL_DATASET = "eval/dataset.json"
+EVAL_SCRIPT = "eval/run_eval.py"
+EVAL_SCORES_LOG = "eval/scores.jsonl"
+EVAL_MARKER = "AUTOSCOUT_EVAL_SCORE:"
+PROPOSE_MAX_TOKENS = 3000
+JUDGE_MAX_TOKENS = 300
+
+SYSTEM_EVAL_PROMPT = (
+    "You are AutoScout's eval-harness designer. Design a FIXED, reusable "
+    "evaluation for this repo's core functionality: a small set of "
+    "representative test cases and a script that scores the repo against "
+    "them. This harness will be reused UNCHANGED on every future cycle to "
+    "measure whether changes help or hurt — so make the cases genuinely "
+    "representative of the problem, not trivially easy to pass.\n\n"
+    f"Write two files:\n"
+    f"1. {EVAL_DATASET} — a JSON array of fixed test cases (inputs and, "
+    "where applicable, expected outputs or acceptance criteria).\n"
+    f"2. {EVAL_SCRIPT} — a self-contained Python script using only this "
+    "repo's existing dependencies or the standard library. It must load "
+    f"{EVAL_DATASET}, exercise the repo's actual core logic against each "
+    "case (synthetic/fixture data only — no real API keys, no network), "
+    "and print EXACTLY ONE line starting with "
+    f"'{EVAL_MARKER} ' followed by a single-line JSON object that MUST "
+    "include a numeric 'score' field where HIGHER IS ALWAYS BETTER (e.g. "
+    "a pass rate, or an inverted latency), plus any other detail metrics "
+    "you want tracked over time.\n\n"
+    "Output in EXACTLY this form:\n"
+    f"=== {EVAL_DATASET} ===\n<json content>\n"
+    f"=== {EVAL_SCRIPT} ===\n<script content>\n"
+)
+
+PROPOSE_TEMPLATE = """\
+Repo: {full_name}
+Problem: {topic}
+
+Current files:
+{file_dump}
+
+Design the fixed eval harness per your instructions.
+"""
+
+JUDGE_TEMPLATE = """\
+A repo just went through one maturation cycle. Give your honest opinion of \
+whether this cycle's change was a genuine improvement.
+
+What changed (diff-relevant files, before -> after):
+{diff_summary}
+
+Deterministic eval score: before={before_score}, after={after_score} \
+(higher is better; this is measured, not your opinion — you may agree or \
+disagree with it).
+
+Respond with ONLY a JSON object: {{"quality_score": <1-10 integer>, \
+"reasoning": "<one sentence>"}}
+"""
+
+
+def build_propose_prompt(entry: dict, files: dict[str, str]) -> str:
+    dump = "\n\n".join(f"----- FILE: {path} -----\n{content}"
+                       for path, content in files.items())
+    return PROPOSE_TEMPLATE.format(
+        full_name=entry["full_name"], topic=entry.get("topic", entry["name"]),
+        file_dump=dump)
+
+
+def parse_harness_proposal(raw: str) -> dict[str, str] | None:
+    pattern = r"=== (eval/[\w.\-]+) ===\n(.*?)(?==== eval/[\w.\-]+ ===|\Z)"
+    files: dict[str, str] = {}
+    for match in re.finditer(pattern, raw, re.DOTALL):
+        path = match.group(1).strip()
+        if ".." in path.split("/"):
+            continue
+        files[path] = match.group(2).strip()
+    if EVAL_DATASET not in files or EVAL_SCRIPT not in files:
+        return None
+    return files
+
+
+def propose_eval_harness(call_llm, api_key: str, entry: dict,
+                         files: dict[str, str]) -> dict[str, str] | None:
+    try:
+        raw = call_llm(api_key, build_propose_prompt(entry, files),
+                       SYSTEM_EVAL_PROMPT, max_tokens=PROPOSE_MAX_TOKENS)
+    except RuntimeError as e:
+        print(f"  eval harness: proposal call failed: {e}")
+        return None
+    return parse_harness_proposal(raw)
+
+
+def freeze_eval_files(edited: dict[str, str], original_files: dict[str, str]) -> dict[str, str]:
+    """Drops any attempted edit to the eval harness files if they already
+    existed before this cycle — structurally impossible to rewrite,
+    regardless of whether the model tries to."""
+    return {path: content for path, content in edited.items()
+           if not (path in (EVAL_DATASET, EVAL_SCRIPT) and path in original_files)}
+
+
+def run_eval(files: dict[str, str]) -> dict | None:
+    if EVAL_SCRIPT not in files:
+        return None
+    run = run_script_in_sandbox(files, EVAL_SCRIPT)
+    if run["status"] != "ran":
+        print(f"  eval harness: {EVAL_SCRIPT} failed to run ({run['reason']})")
+        return None
+    result = extract_marker_json(run["output"], EVAL_MARKER)
+    if result is None or "score" not in result:
+        print(f"  eval harness: {EVAL_SCRIPT} produced no usable score")
+        return None
+    return result
+
+
+def is_regression(before: dict | None, after: dict | None) -> bool:
+    """True only when both scores are real numbers and after < before — an
+    unavailable score on either side is inconclusive, not a regression, and
+    never blocks a push on its own."""
+    if not before or not after:
+        return False
+    try:
+        return float(after["score"]) < float(before["score"])
+    except (TypeError, ValueError, KeyError):
+        return False
+
+
+def _parse_json_object(raw: str) -> dict | None:
+    match = re.search(r"\{.*\}", raw, re.DOTALL)
+    if not match:
+        return None
+    try:
+        return json.loads(match.group(0))
+    except json.JSONDecodeError:
+        return None
+
+
+def judge_score(call_llm, api_key: str, diff_summary: str,
+                before_score: dict | None, after_score: dict | None) -> dict | None:
+    """Non-gating: a second opinion logged alongside the deterministic
+    score, never itself a reason to discard a change (see module docstring)."""
+    try:
+        raw = call_llm(api_key, JUDGE_TEMPLATE.format(
+            diff_summary=diff_summary[:2000],
+            before_score=json.dumps(before_score), after_score=json.dumps(after_score)),
+            "You are a terse, honest code-quality judge.", max_tokens=JUDGE_MAX_TOKENS)
+    except RuntimeError as e:
+        print(f"  eval harness: judge call failed: {e}")
+        return None
+    return _parse_json_object(raw)
+
+
+def append_score_log(old_log: str, today: str, iteration: int, score: dict | None,
+                     judge: dict | None) -> str:
+    entry = {"date": today, "iteration": iteration, "score": score, "judge": judge}
+    line = json.dumps(entry, ensure_ascii=False)
+    return (old_log.rstrip("\n") + "\n" if old_log.strip() else "") + line + "\n"

--- a/scripts/groq_research_client.py
+++ b/scripts/groq_research_client.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Minimal Groq call wrapper, dedicated to the research/eval stages.
+
+AutoScout-Lab's main maturation loop runs on Gemini. The research stage
+(research.py) and eval-judge scoring (eval_harness.py) intentionally use a
+SEPARATE Groq key (GROQ_RESEARCH_API_KEY) so their extra calls never compete
+with the main maturation budget or quota — a quota-isolation choice, not a
+capability one. Kept as its own tiny module rather than pulling in
+AutoScout-Engine's groq_common.py, since Lab and Engine are deliberately
+independent (see registry.py's docstring in Engine)."""
+
+import json
+import sys
+import time
+import urllib.error
+import urllib.request
+
+GROQ_API_URL = "https://api.groq.com/openai/v1/chat/completions"
+MODEL = "llama-3.3-70b-versatile"
+MAX_RETRIES = 2
+RETRY_BASE_SEC = 20
+
+
+def _is_transient(err: str) -> bool:
+    if any(x in err for x in ("404", "403", "401")):
+        return False
+    keywords = ("429", "503", "rate limit", "overloaded", "unavailable", "retry")
+    return any(k.lower() in err.lower() for k in keywords)
+
+
+def call_groq(api_key: str, prompt: str, system: str, max_tokens: int) -> str:
+    """One prompt -> response text via Groq's OpenAI-compatible endpoint."""
+    body = json.dumps({
+        "model": MODEL,
+        "messages": [
+            {"role": "system", "content": system},
+            {"role": "user", "content": prompt},
+        ],
+        "max_tokens": max_tokens,
+        "temperature": 0.5,
+    }).encode()
+
+    for attempt in range(1, MAX_RETRIES + 1):
+        req = urllib.request.Request(GROQ_API_URL, data=body, method="POST")
+        req.add_header("Authorization", f"Bearer {api_key}")
+        req.add_header("Content-Type", "application/json")
+        req.add_header("Accept", "application/json")
+        # Groq sits behind Cloudflare, which blocks urllib's default
+        # "Python-urllib/x.x" User-Agent as a bot signature (403, code 1010).
+        req.add_header("User-Agent", "Mozilla/5.0 (compatible; AutoScout-Lab/1.0)")
+        try:
+            with urllib.request.urlopen(req, timeout=120) as resp:
+                data = json.loads(resp.read())
+                text = data["choices"][0]["message"]["content"]
+                if not text:
+                    raise RuntimeError("empty response")
+                return text
+        except urllib.error.HTTPError as e:
+            err_body = e.read().decode(errors="replace")[:300]
+            err = f"{e.code} {err_body}"
+        except Exception as e:
+            err = str(e)
+
+        if _is_transient(err) and attempt < MAX_RETRIES:
+            wait = RETRY_BASE_SEC * (2 ** (attempt - 1))
+            print(f"  Transient error (attempt {attempt}/{MAX_RETRIES}), "
+                 f"retrying in {wait}s... [{err[:150]}]", flush=True)
+            time.sleep(wait)
+        else:
+            print(f"  Groq call failed after {attempt} attempt(s): {err[:200]}",
+                 file=sys.stderr)
+            break
+
+    raise RuntimeError("Groq API call exhausted retries")

--- a/scripts/mature_repo.py
+++ b/scripts/mature_repo.py
@@ -34,6 +34,8 @@ import urllib.request
 from datetime import date
 from pathlib import Path
 
+import eval_harness
+import groq_research_client
 from digest import update_section
 from repo_registry import load_registry, save_registry, sync_registry
 from research import RESEARCH_LOG, run_research_stage
@@ -342,6 +344,11 @@ def main() -> None:
         print("ERROR: SCOUT_PAT is not set.", file=sys.stderr)
         sys.exit(1)
 
+    # Dedicated to the research stage + eval-harness judge calls, isolated
+    # from the main Gemini maturation budget above. Optional — both stages
+    # are simply skipped if this isn't configured yet.
+    research_key = os.environ.get("GROQ_RESEARCH_API_KEY", "")
+
     print("─── AutoScout: per-repo maturation ───")
     owner = get_authenticated_user(gh_token)
     registry = sync_registry(owner, gh_token)
@@ -364,7 +371,23 @@ def main() -> None:
         save_registry(registry)
         return
 
+    original_files = files  # pre-cycle snapshot — the freeze-check baseline
     old_growth_log = files.get(GROWTH_LOG, "")
+
+    before_score = None
+    harness_files: dict[str, str] = {}
+    if research_key and eval_harness.EVAL_SCRIPT not in files:
+        harness_files = eval_harness.propose_eval_harness(
+            groq_research_client.call_groq, research_key, entry, files) or {}
+        if harness_files:
+            files = {**files, **harness_files}
+            before_score = eval_harness.run_eval(files)
+            print(f"  eval harness: created ({eval_harness.EVAL_DATASET}, "
+                 f"{eval_harness.EVAL_SCRIPT}) — baseline score {before_score}")
+    elif eval_harness.EVAL_SCRIPT in files:
+        before_score = eval_harness.run_eval(files)
+        print(f"  eval harness: baseline score {before_score}")
+
     prompt = build_prompt(entry, files)
 
     try:
@@ -380,6 +403,7 @@ def main() -> None:
              file=sys.stderr)
         print(raw[:1000], file=sys.stderr)
         sys.exit(1)
+    edited = eval_harness.freeze_eval_files(edited, original_files)
 
     verified, reason = verify_with_retries(gemini_key, files, edited)
     if verified is None:
@@ -389,6 +413,13 @@ def main() -> None:
              f"({reason}) — aborting this iteration without pushing.", file=sys.stderr)
         sys.exit(1)
     edited = verified
+    edited.update(harness_files)  # always push a newly-created harness this cycle
+
+    after_score = eval_harness.run_eval({**files, **edited}) if before_score is not None else None
+    if eval_harness.is_regression(before_score, after_score):
+        print(f"ERROR: eval score regressed ({before_score} -> {after_score}) — "
+             "aborting this iteration without pushing.", file=sys.stderr)
+        sys.exit(1)
 
     iteration = entry.get("iterations", 0) + 1
     today = date.today().isoformat()
@@ -405,15 +436,31 @@ def main() -> None:
     summary = commit_summary(old_growth_log, new_growth_log)
 
     old_research_log = files.get(RESEARCH_LOG, "")
-    research_files, research_entry = run_research_stage(
-        call_gemini, gemini_key, entry, {**files, **edited}, old_research_log,
-        today, iteration)
-    if research_entry:
-        edited[RESEARCH_LOG] = (old_research_log.rstrip("\n") + "\n\n" if old_research_log.strip()
-                                else "") + research_entry
-        edited.update(research_files)
-        summary += " + research"
-        print(f"  research  : {research_entry.splitlines()[1]}")
+    if research_key:
+        research_files, research_entry = run_research_stage(
+            groq_research_client.call_groq, research_key, entry, {**files, **edited},
+            old_research_log, today, iteration)
+        if research_entry:
+            edited[RESEARCH_LOG] = (old_research_log.rstrip("\n") + "\n\n"
+                                    if old_research_log.strip() else "") + research_entry
+            edited.update(research_files)
+            summary += " + research"
+            print(f"  research  : {research_entry.splitlines()[1]}")
+
+    if before_score is not None:
+        old_scores_log = files.get(eval_harness.EVAL_SCORES_LOG, "")
+        judge = None
+        if research_key:
+            diff_summary = "\n\n".join(
+                f"--- {p} ---\n{c[:800]}" for p, c in edited.items()
+                if p not in (eval_harness.EVAL_DATASET, eval_harness.EVAL_SCRIPT,
+                            eval_harness.EVAL_SCORES_LOG))
+            judge = eval_harness.judge_score(groq_research_client.call_groq, research_key,
+                                             diff_summary, before_score, after_score)
+        edited[eval_harness.EVAL_SCORES_LOG] = eval_harness.append_score_log(
+            old_scores_log, today, iteration, after_score, judge)
+        summary += " + eval"
+        print(f"  eval score : {before_score} -> {after_score}  (judge: {judge})")
 
     try:
         push_maturation(full_name, edited, gh_token, iteration, summary)

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -15,6 +15,7 @@ is flagged as a real bug. Ambiguous cases (timeouts, infra hiccups) default
 to passing rather than blocking a push on a false positive.
 """
 
+import json
 import re
 import subprocess
 import tempfile
@@ -167,3 +168,17 @@ def run_script_in_sandbox(files: dict[str, str], script_filename: str,
             return {"status": "error", "output": result.stdout + result.stderr,
                     "reason": f"exit code {result.returncode}: {result.stderr[-300:]}"}
         return {"status": "ran", "output": result.stdout, "reason": "clean exit"}
+
+
+def extract_marker_json(stdout: str, marker: str) -> dict | None:
+    """Finds the first line starting with `marker` and parses the JSON that
+    follows it. Shared by research.py and eval_harness.py — the one place
+    both trust a script's claimed numbers, because it's this function (not
+    the model) doing the reading."""
+    for line in stdout.splitlines():
+        if line.startswith(marker):
+            try:
+                return json.loads(line[len(marker):].strip())
+            except json.JSONDecodeError:
+                return None
+    return None

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -7,6 +7,7 @@ generated code in a sandbox (that's the point of the module under test).
 Run: python3 -m unittest discover tests -v
 """
 
+import json
 import sys
 import unittest
 import unittest.mock
@@ -15,6 +16,9 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 import mature_repo  # noqa: E402 — imported as a module so call_gemini can be patched
+from eval_harness import (append_score_log, freeze_eval_files,  # noqa: E402
+                          is_regression, judge_score, parse_harness_proposal,
+                          run_eval)
 from generate_prototype import derive_topics  # noqa: E402
 from mature_repo import commit_summary, pick_due_repo, sanitize_log  # noqa: E402
 from research import (extract_result, parse_research_proposal,  # noqa: E402
@@ -324,6 +328,79 @@ class TestRunResearchStage(unittest.TestCase):
             {"main.py": "print('hi')\n"}, "", "2026-07-27", 1)
         self.assertEqual(extra_files, {})
         self.assertIn("unverified", entry_text)
+
+
+class TestEvalHarnessParsing(unittest.TestCase):
+    def test_valid_proposal_parsed(self):
+        raw = ("=== eval/dataset.json ===\n[{\"input\": 1}]\n"
+              "=== eval/run_eval.py ===\nprint('AUTOSCOUT_EVAL_SCORE: {\"score\": 1.0}')\n")
+        parsed = parse_harness_proposal(raw)
+        self.assertIn("eval/dataset.json", parsed)
+        self.assertIn("eval/run_eval.py", parsed)
+
+    def test_missing_script_rejected(self):
+        raw = "=== eval/dataset.json ===\n[]\n"
+        self.assertIsNone(parse_harness_proposal(raw))
+
+    def test_path_traversal_rejected(self):
+        raw = ("=== eval/dataset.json ===\n[]\n"
+              "=== eval/../../evil.py ===\nprint('hi')\n")
+        parsed = parse_harness_proposal(raw)
+        self.assertIsNone(parsed)
+
+
+class TestFreezeEvalFiles(unittest.TestCase):
+    def test_pre_existing_eval_files_stripped(self):
+        original = {"eval/dataset.json": "[]", "eval/run_eval.py": "old"}
+        edited = {"eval/run_eval.py": "model tried to rewrite this",
+                 "main.py": "print(1)"}
+        result = freeze_eval_files(edited, original)
+        self.assertNotIn("eval/run_eval.py", result)
+        self.assertIn("main.py", result)
+
+    def test_newly_created_eval_files_not_stripped(self):
+        # not in `original` (didn't exist before this cycle) — allowed through
+        edited = {"eval/run_eval.py": "brand new"}
+        result = freeze_eval_files(edited, {})
+        self.assertIn("eval/run_eval.py", result)
+
+
+class TestIsRegression(unittest.TestCase):
+    def test_lower_after_is_regression(self):
+        self.assertTrue(is_regression({"score": 5.0}, {"score": 3.0}))
+
+    def test_equal_or_higher_is_not_regression(self):
+        self.assertFalse(is_regression({"score": 5.0}, {"score": 5.0}))
+        self.assertFalse(is_regression({"score": 5.0}, {"score": 9.0}))
+
+    def test_missing_score_is_inconclusive_not_regression(self):
+        self.assertFalse(is_regression(None, {"score": 1.0}))
+        self.assertFalse(is_regression({"score": 5.0}, None))
+
+
+class TestJudgeScore(unittest.TestCase):
+    def test_parses_json_from_model_response(self):
+        call_llm = unittest.mock.Mock(
+            return_value='{"quality_score": 8, "reasoning": "solid improvement"}')
+        result = judge_score(call_llm, "fake-key", "diff", {"score": 1}, {"score": 2})
+        self.assertEqual(result["quality_score"], 8)
+
+    def test_unparseable_response_returns_none(self):
+        call_llm = unittest.mock.Mock(return_value="not json at all")
+        self.assertIsNone(judge_score(call_llm, "fake-key", "diff", {"score": 1}, {"score": 2}))
+
+
+class TestAppendScoreLog(unittest.TestCase):
+    def test_appends_valid_json_line(self):
+        log = append_score_log("", "2026-07-27", 1, {"score": 3.0}, {"quality_score": 7})
+        entry = json.loads(log.strip())
+        self.assertEqual(entry["iteration"], 1)
+        self.assertEqual(entry["score"]["score"], 3.0)
+
+
+class TestRunEvalNoScript(unittest.TestCase):
+    def test_missing_script_returns_none(self):
+        self.assertIsNone(run_eval({"main.py": "print(1)"}))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `scripts/eval_harness.py`: on a repo's first cycle with `GROQ_RESEARCH_API_KEY` set, the model proposes a FIXED `eval/dataset.json` + `eval/run_eval.py` once.
- Every cycle after, both files are frozen — `freeze_eval_files()` deterministically strips any attempted model edit to them, regardless of prompt compliance.
- Every cycle runs the same eval before and after its edit via the sandbox; a measured score regression aborts the push exactly like a verify failure.
- A separate LLM-judge opinion is also collected and logged to `eval/scores.jsonl` for a longitudinal trend, but is explicitly non-gating (a judge call has run-to-run noise a measured score doesn't).
- Adds `scripts/groq_research_client.py`: a dedicated Groq key for the research stage + judge scoring, isolated from the main Gemini maturation budget.
- The research stage (previous PR #29) now runs on this same dedicated key instead of the main Gemini key.

## Setup required
- Add a `GROQ_RESEARCH_API_KEY` secret to this repo's Actions secrets (a Groq key, separate from any existing Groq key in AutoScout-Engine) to activate both the research stage and this eval harness. Without it, both stages are simply skipped.

## Test plan
- [x] `python3.12 -m unittest discover tests` — 59 tests, all pass except 6 requiring real sandbox venv creation (local `ensurepip`/PEP 668 quirk; passes in CI).
- [ ] Watch the first repo to get a harness created — confirm `eval/dataset.json` + `eval/run_eval.py` land and stay frozen on the next cycle.