### PR TITLE
Fix: multi-command CLI usage error misclassified as a bug

### DIFF
--- a/scripts/groq_research_client.py
+++ b/scripts/groq_research_client.py
@@ -24,6 +24,14 @@ RETRY_BASE_SEC = 20
 def _is_transient(err: str) -> bool:
     if any(x in err for x in ("404", "403", "401")):
         return False
+    # A 413 naming "tokens per minute" is a rolling-60s-window collision —
+    # multiple Groq calls (research propose/interpret, judge score, and
+    # AutoScout-Engine's own advancement call if this account shares an
+    # org) landing within the same window — not one oversized payload.
+    # A short wait clears it, same as a 429; see AutoScout-Engine's
+    # groq_common.py for the real incident this was found from.
+    if "413" in err and "tokens per minute" in err.lower():
+        return True
     keywords = ("429", "503", "rate limit", "overloaded", "unavailable", "retry")
     return any(k.lower() in err.lower() for k in keywords)
 

--- a/scripts/mature_repo.py
+++ b/scripts/mature_repo.py
@@ -225,12 +225,23 @@ No markdown fences inside any file's content.
 """
 
 
+PROMPT_DUMP_EXCLUDE_PREFIXES = ("research/", "eval/")
+
+
 def build_prompt(entry: dict, files: dict[str, str]) -> str:
     growth_log = files.get(GROWTH_LOG,
                            "(none yet — this is truly the first maturation cycle; "
                            "do not invent any earlier entries.)")
+    # research.py's benchmark scripts and eval_harness.py's frozen harness
+    # are read separately by those modules directly — they don't need to
+    # also ride along in this prompt's own dump. Gemini's budget here is
+    # much larger than Groq's, but a repo with enough accumulated cycles
+    # could still hit it eventually (see AutoScout-Engine's 2026-07-29/30
+    # incident on the same underlying pattern, hit there first only
+    # because its TPM limit is far smaller).
     dump = "\n\n".join(f"----- FILE: {path} -----\n{content}"
-                       for path, content in files.items())
+                       for path, content in files.items()
+                       if not path.startswith(PROMPT_DUMP_EXCLUDE_PREFIXES))
     return MATURE_TEMPLATE.format(
         full_name=entry["full_name"],
         topic=entry.get("topic", entry["name"]),

--- a/scripts/research.py
+++ b/scripts/research.py
@@ -85,9 +85,13 @@ above — no other numeric claim.
 """
 
 
+CONTEXT_DUMP_EXCLUDE_PREFIXES = ("research/", "eval/")
+
+
 def build_propose_prompt(entry: dict, files: dict[str, str], research_log: str) -> str:
     dump = "\n\n".join(f"----- FILE: {path} -----\n{content}"
-                       for path, content in files.items())
+                       for path, content in files.items()
+                       if not path.startswith(CONTEXT_DUMP_EXCLUDE_PREFIXES))
     return PROPOSE_TEMPLATE.format(
         full_name=entry["full_name"],
         topic=entry.get("topic", entry["name"]),

--- a/scripts/verify.py
+++ b/scripts/verify.py
@@ -46,6 +46,15 @@ BENIGN_EXCEPTIONS = {"EOFError", "KeyboardInterrupt", "SystemExit"}
 AUTH_KEYWORDS = ("api key", "apikey", "unauthorized", "authentication",
                  "permission_denied", "invalid_api_key", "401", "403",
                  "credentials", "api_key_invalid")
+# A multi-command Typer/Click CLI run with zero args (our smoke test never
+# passes a subcommand) always exits non-zero with a rich-styled box ending
+# in a border line, not a recognizable "SomeError:" line — e.g.:
+#   ╭─ Error ──────────────────────╮
+#   │ Missing command.             │
+#   ╰──────────────────────────────╯
+# This is the CLI correctly asking for a subcommand, not a code defect.
+CLI_USAGE_KEYWORDS = ("missing command", "no such command", "missing argument",
+                      "missing option", "try '--help'", 'try "--help"')
 
 
 def _classify_failure(stderr: str) -> tuple[bool, str]:
@@ -60,6 +69,9 @@ def _classify_failure(stderr: str) -> tuple[bool, str]:
         return False, last
     if any(k in stderr.lower() for k in AUTH_KEYWORDS):
         return True, "failed on API auth with a dummy key — expected"
+    if any(k in stderr.lower() for k in CLI_USAGE_KEYWORDS):
+        return True, ("CLI requires an explicit subcommand/argument — expected "
+                      "when smoke-tested with none")
     if exc_name:
         return False, last
     return False, f"non-zero exit, no recognizable exception: {last[:200]}"

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -26,7 +26,7 @@ from research import (extract_result, parse_research_proposal,  # noqa: E402
 from scout_common import (broken_python_files, parse_json_lenient,  # noqa: E402
                           parse_sections, slugify)
 from scout_problems import find_near_duplicate  # noqa: E402
-from verify import verify_python_repo  # noqa: E402
+from verify import _classify_failure, verify_python_repo  # noqa: E402
 
 
 class TestParseSections(unittest.TestCase):
@@ -201,6 +201,28 @@ class TestVerifyPythonRepo(unittest.TestCase):
 
     def test_interactive_input_eof_passes(self):
         self.assertTrue(verify_python_repo({"main.py": "input('prompt> ')\n"})["ok"])
+
+class TestClassifyFailureCliUsage(unittest.TestCase):
+    def test_rich_boxed_missing_command_is_benign(self):
+        # A Typer/Click CLI with >1 @app.command() exits 2 with a rich-styled
+        # box when run with zero args — the exact failure mode that caused a
+        # real maturation run to wrongly abort (see 2026-07-29 incident): the
+        # last line is just a box border, not a recognizable "SomeError:".
+        stderr = (
+            "Usage: main.py [OPTIONS] COMMAND [ARGS]...\n"
+            "Try 'main.py --help' for help.\n"
+            "╭─ Error ────────────────────────────────────────────\n"
+            "│ Missing command. │\n"
+            "╰────────────────────────────────────────────╯\n"
+        )
+        ok, reason = _classify_failure(stderr)
+        self.assertTrue(ok)
+        self.assertIn("subcommand", reason)
+
+    def test_real_structural_bug_still_flagged(self):
+        stderr = "Traceback (most recent call last):\nNameError: name 'x' is not defined\n"
+        ok, reason = _classify_failure(stderr)
+        self.assertFalse(ok)
 
 
 class TestVerifyWithRetries(unittest.TestCase):

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -20,9 +20,11 @@ from eval_harness import (append_score_log, freeze_eval_files,  # noqa: E402
                           is_regression, judge_score, parse_harness_proposal,
                           run_eval)
 from generate_prototype import derive_topics  # noqa: E402
-from mature_repo import commit_summary, pick_due_repo, sanitize_log  # noqa: E402
-from research import (extract_result, parse_research_proposal,  # noqa: E402
-                      run_research_stage, sanitize_interpretation)
+from mature_repo import (build_prompt, commit_summary,  # noqa: E402
+                         pick_due_repo, sanitize_log)
+from research import (build_propose_prompt, extract_result,  # noqa: E402
+                      parse_research_proposal, run_research_stage,
+                      sanitize_interpretation)
 from scout_common import (broken_python_files, parse_json_lenient,  # noqa: E402
                           parse_sections, slugify)
 from scout_problems import find_near_duplicate  # noqa: E402
@@ -423,6 +425,34 @@ class TestAppendScoreLog(unittest.TestCase):
 class TestRunEvalNoScript(unittest.TestCase):
     def test_missing_script_returns_none(self):
         self.assertIsNone(run_eval({"main.py": "print(1)"}))
+
+
+class TestPromptDumpExcludesArtifacts(unittest.TestCase):
+    """Real incident (2026-07-29/30, AutoScout-Engine): research/eval
+    artifact files riding along in the main prompt's file dump pushed a
+    long-lived repo's advancement call over Groq's 12,000 TPM limit (413
+    Request too large). The fix applies here too, ahead of Gemini's much
+    larger budget ever hitting the same wall."""
+
+    entry = {"full_name": "x/y", "name": "y", "topic": "t", "iterations": 0}
+
+    def test_research_and_eval_files_excluded_from_dump(self):
+        files = {
+            "main.py": "print('core')",
+            "research/bench_1.py": "print('AUTOSCOUT_RESEARCH_RESULT: {}')",
+            "eval/dataset.json": "[]",
+            "eval/run_eval.py": "print('AUTOSCOUT_EVAL_SCORE: {}')",
+        }
+        prompt = build_prompt(self.entry, files)
+        self.assertIn("main.py", prompt)
+        self.assertNotIn("bench_1.py", prompt)
+        self.assertNotIn("run_eval.py", prompt)
+
+    def test_research_propose_prompt_also_excludes_artifacts(self):
+        files = {"main.py": "print('core')", "eval/run_eval.py": "print('x')"}
+        prompt = build_propose_prompt(self.entry, files, "")
+        self.assertIn("main.py", prompt)
+        self.assertNotIn("run_eval.py", prompt)
 
 
 if __name__ == "__main__":

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -20,6 +20,7 @@ from eval_harness import (append_score_log, freeze_eval_files,  # noqa: E402
                           is_regression, judge_score, parse_harness_proposal,
                           run_eval)
 from generate_prototype import derive_topics  # noqa: E402
+from groq_research_client import _is_transient as _groq_research_is_transient  # noqa: E402
 from mature_repo import (build_prompt, commit_summary,  # noqa: E402
                          pick_due_repo, sanitize_log)
 from research import (build_propose_prompt, extract_result,  # noqa: E402
@@ -453,6 +454,22 @@ class TestPromptDumpExcludesArtifacts(unittest.TestCase):
         prompt = build_propose_prompt(self.entry, files, "")
         self.assertIn("main.py", prompt)
         self.assertNotIn("run_eval.py", prompt)
+
+
+class TestGroqResearchClientIsTransientTpmCollision(unittest.TestCase):
+    """Same fix as AutoScout-Engine's groq_common.py — see that repo's
+    2026-07-29/30/31 incident. Applied here too since research.py's
+    propose/interpret calls and eval_harness.py's judge_score call all go
+    through this same client and can collide in the same way."""
+
+    def test_tpm_413_is_transient(self):
+        err = ('413 {"error":{"message":"Request too large ... on tokens '
+              'per minute (TPM): Limit 12000, Requested 12500"}}')
+        self.assertTrue(_groq_research_is_transient(err))
+
+    def test_unrelated_413_not_transient(self):
+        self.assertFalse(_groq_research_is_transient(
+            '413 {"error":{"message":"Payload too large"}}'))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
Fixes a real incident from 2026-07-29: the `Repo Maturation Loop` run aborted `inconsistent-tool-calling-and-api-compatibility-2026-07-19` after 2 wasted fix-retry attempts.

Root cause: that repo is a Typer/Click CLI with multiple `@app.command()` entries. Our sandbox smoke test runs `python main.py` with zero args, which correctly exits 2 with a rich-styled box (`Missing command.`) — but `_classify_failure()` only checks the LAST stderr line for a `SomeError:` pattern, and here that's just a box-drawing border character. It defaulted to "real bug" and burned two pointless fix attempts against code that was never broken.

Adds `CLI_USAGE_KEYWORDS`, checked the same way `AUTH_KEYWORDS` already is.

## Test plan
- [x] Reproduced the exact box output locally with a real Typer CLI, confirmed the fix classifies it as benign via `_classify_failure()` directly (bypasses the local sandbox venv limitation).
- [x] Full suite: 61 tests, only the 6 requiring real sandbox venv creation fail locally (known `ensurepip` quirk, passes in CI).